### PR TITLE
:bug: PATCH fix ls table display

### DIFF
--- a/program/commands/command_list.py
+++ b/program/commands/command_list.py
@@ -3,7 +3,7 @@ from program.commands import commands
 cmd = {
     'help': commands.helps,
     'ls': commands.ls,
-    'os': commands.os,
+    'os': commands.os_command,
     'python': commands.python,
 }
 

--- a/program/commands/commands.py
+++ b/program/commands/commands.py
@@ -1,4 +1,6 @@
 import os
+from datetime import datetime
+
 from tabulate import tabulate
 from colorama import Fore, Back, Style
 from itertools import chain
@@ -50,7 +52,7 @@ def helps(args):
         print(Fore.RED + "the argument you want to use is invalid or misspelled" + Style.RESET_ALL)
 
 # os
-def os(args):
+def os_command(args):
     import main
     if len(args) == 0:
         require_argument("os")


### PR DESCRIPTION
- Fix `ls` crash due to name shadowing cause the `os` module to be replaced by the `os` function